### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, UC Santa Barbara
+Copyright (c) 2025, Regents of the University of California
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Karla pointed out that the UCs aren't legal entities and the copyright holder should be "Regents of the University of California".